### PR TITLE
Add paper on phase transitions in LLMs via O(N) model

### DIFF
--- a/papers/phenomena-of-interest/scaling-laws/papers.csv
+++ b/papers/phenomena-of-interest/scaling-laws/papers.csv
@@ -52,3 +52,4 @@ How Does Critical Batch Size Scale in Pre-training?,2024-10-29,http://arxiv.org/
 Unlocking the Theory Behind Scaling 1-Bit Neural Networks,2024-11-03,http://arxiv.org/abs/2411.01663,Majid Daliri; Zhao Song; Chiwun Yang
 Scaling Laws for Precision,2024-11-07,http://arxiv.org/abs/2411.04330,Tanishq Kumar; Zachary Ankner; Benjamin F. Spector; Blake Bordelon; Niklas Muennighoff; Mansheej Paul; Cengiz Pehlevan; Christopher Ré; Aditi Raghunathan
 Understanding Scaling Laws with Statistical and Approximation Theory for Transformer Neural Networks on Intrinsically Low-dimensional Data,2024-11-11,http://arxiv.org/abs/2411.06646,Alex Havrilla; Wenjing Liao
+Phase Transitions in Large Language Models and the $O(N)$ Model,2025-01-27,http://arxiv.org/abs/2501.16241,Youran Sun; Babak Haghighat


### PR DESCRIPTION
Hi! Adding a paper to the Scaling Laws section:

**Phase Transitions in Large Language Models and the O(N) Model**

It connects Transformer scaling behavior to the O(N) model in statistical physics, identifying two phase transitions and estimating an internal dimension of about 6 from critical exponents.

Only edited `papers/phenomena-of-interest/scaling-laws/papers.csv` as described in CONTRIBUTING.md.